### PR TITLE
Switch funsor backend to use funsor.compat.ops

### DIFF
--- a/pyroapi/dispatch.py
+++ b/pyroapi/dispatch.py
@@ -77,7 +77,7 @@ _ALIASES = {
         'distributions': 'funsor.distributions',
         'handlers': 'funsor.minipyro',
         'infer': 'funsor.minipyro',
-        'ops': 'funsor.ops',
+        'ops': 'funsor.compat.ops',
         'optim': 'funsor.minipyro',
         'pyro': 'funsor.minipyro',
     },

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
             'pytest>=5.0',
             'pyro-ppl@https://api.github.com/repos/pyro-ppl/pyro/tarball/7caad72',
             'numpyro@https://api.github.com/repos/pyro-ppl/numpyro/tarball/7174846',
-            'funsor@https://api.github.com/repos/pyro-ppl/funsor/tarball/3d6197f',
+            'funsor@https://api.github.com/repos/pyro-ppl/funsor/tarball/7810696',
         ],
         'dev': ['ipython'],
     },


### PR DESCRIPTION
Follows https://github.com/pyro-ppl/funsor/pull/270