### PR TITLE
Add register_backend() function

### DIFF
--- a/docs/source/dispatch.rst
+++ b/docs/source/dispatch.rst
@@ -1,37 +1,9 @@
 Dispatch
 ========
 
-It's easiest to see how to use pyroapi by example:
-
-.. code-block:: python
-
-    from pyroapi import distributions as dist
-    from pyroapi import infer, ops, optim, pyro, pyro_backend
-
-    # These model and guide are backend-agnostic.
-    def model():
-        locs = pyro.param("locs", ops.tensor([0.2, 0.3, 0.5]))
-        p = ops.tensor([0.2, 0.3, 0.5])
-        with pyro.plate("plate", len(data), dim=-1):
-            x = pyro.sample("x", dist.Categorical(p))
-            pyro.sample("obs", dist.Normal(locs[x], 1.), obs=data)
-
-    def guide():
-        p = pyro.param("p", ops.tensor([0.5, 0.3, 0.2]))
-        with pyro.plate("plate", len(data), dim=-1):
-            pyro.sample("x", dist.Categorical(p))
-
-    # We can now set a backend at inference time.
-    with pyro_backend("numpyro"):
-        elbo = infer.Trace_ELBO(ignore_jit_warnings=True)
-        adam = optim.Adam({"lr": 1e-6})
-        inference = infer.SVI(model, guide, adam, elbo)
-        for step in range(10):
-            loss = inference.step(*args, **kwargs)
-            print(f"step {step} loss = {loss}")
-
 .. automodule:: pyroapi.dispatch
 .. autofunction:: pyroapi.dispatch.pyro_backend
+.. autofunction:: pyroapi.dispatch.register_backend
 
 Generic Modules
 ---------------

--- a/pyroapi/__init__.py
+++ b/pyroapi/__init__.py
@@ -1,4 +1,4 @@
-from pyroapi.dispatch import distributions, handlers, infer, ops, optim, pyro, pyro_backend
+from pyroapi.dispatch import distributions, handlers, infer, ops, optim, pyro, pyro_backend, register_backend
 
 __all__ = [
     'distributions',
@@ -8,4 +8,5 @@ __all__ = [
     'optim',
     'pyro',
     'pyro_backend',
+    'register_backend',
 ]

--- a/pyroapi/dispatch.py
+++ b/pyroapi/dispatch.py
@@ -1,7 +1,41 @@
+"""
+Dispatching allows you to dynamically set a backend using :func:`pyro_backend`
+and to register new backends using :func:`register_backend` .  It's easiest to
+see how to use these by example:
+
+.. code-block:: python
+
+    from pyroapi import distributions as dist
+    from pyroapi import infer, ops, optim, pyro, pyro_backend
+
+    # These model and guide are backend-agnostic.
+    def model():
+        locs = pyro.param("locs", ops.tensor([0.2, 0.3, 0.5]))
+        p = ops.tensor([0.2, 0.3, 0.5])
+        with pyro.plate("plate", len(data), dim=-1):
+            x = pyro.sample("x", dist.Categorical(p))
+            pyro.sample("obs", dist.Normal(locs[x], 1.), obs=data)
+
+    def guide():
+        p = pyro.param("p", ops.tensor([0.5, 0.3, 0.2]))
+        with pyro.plate("plate", len(data), dim=-1):
+            pyro.sample("x", dist.Categorical(p))
+
+    # We can now set a backend at inference time.
+    with pyro_backend("numpyro"):
+        elbo = infer.Trace_ELBO(ignore_jit_warnings=True)
+        adam = optim.Adam({"lr": 1e-6})
+        inference = infer.SVI(model, guide, adam, elbo)
+        for step in range(10):
+            loss = inference.step(*args, **kwargs)
+            print(f"step {step} loss = {loss}")
+
+"""
 import importlib
 from contextlib import contextmanager
 
 DEFAULT_RNG_SEED = 1
+_ALIASES = {}
 
 
 class GenericModule(object):
@@ -38,9 +72,10 @@ def pyro_backend(*aliases, **new_backends):
     """
     Context manager to set a custom backend for Pyro models.
 
-    Backends can be specified either by name (for standard backends)
-    or by providing a dict mapping module name to backend module name.
-    Standard backends include: pyro, minipyro, funsor, and numpy.
+    Backends can be specified either by name (for standard backends or backends
+    registered through :func:`register_backend` ) or by providing a dict
+    mapping module name to backend module name.  Standard backends include:
+    pyro, minipyro, funsor, and numpy.
     """
     if aliases:
         assert len(aliases) == 1
@@ -59,40 +94,26 @@ def pyro_backend(*aliases, **new_backends):
             GenericModule.current_backend[name] = old_backend
 
 
-_ALIASES = {
-    'pyro': {
-        'distributions': 'pyro.distributions',
-        'handlers': 'pyro.poutine',
-        'infer': 'pyro.infer',
-        'ops': 'torch',
-        'optim': 'pyro.optim',
-        'pyro': 'pyro',
-    },
-    'minipyro': {
-        'distributions': 'pyro.distributions',
-        'handlers': 'pyro.poutine',
-        'infer': 'pyro.contrib.minipyro',
-        'ops': 'torch',
-        'optim': 'pyro.contrib.minipyro',
-        'pyro': 'pyro.contrib.minipyro',
-    },
-    'funsor': {
-        'distributions': 'funsor.distributions',
-        'handlers': 'funsor.minipyro',
-        'infer': 'funsor.minipyro',
-        'ops': 'funsor.compat.ops',
-        'optim': 'funsor.minipyro',
-        'pyro': 'funsor.minipyro',
-    },
-    'numpy': {
-        'distributions': 'numpyro.compat.distributions',
-        'handlers': 'numpyro.compat.handlers',
-        'infer': 'numpyro.compat.infer',
-        'ops': 'numpyro.compat.ops',
-        'optim': 'numpyro.compat.optim',
-        'pyro': 'numpyro.compat.pyro',
-    },
-}
+def register_backend(alias, new_backends):
+    """
+    Register a new backend alias. For example::
+
+        register_backend("minipyro", {
+            "infer": "pyro.contrib.minipyro",
+            "optim": "pyro.contrib.minipyro",
+            "pyro": "pyro.contrib.minipyro",
+        })
+
+    :param str alias: The name of the new backend.
+    :param dict new_backends: A dict mapping standard module name (str) to new
+        module name (str). This needs to include only nonstandard backends
+        (e.g. if your backend uses torch ops, you need not override ``ops``)
+    """
+    assert isinstance(new_backends, dict)
+    assert all(isinstance(key, str) for key in new_backends.keys())
+    assert all(isinstance(value, str) for value in new_backends.values())
+    _ALIASES[alias] = new_backends.copy()
+
 
 # These modules can be overridden.
 pyro = GenericModule('pyro', 'pyro')
@@ -101,3 +122,38 @@ handlers = GenericModule('handlers', 'pyro.poutine')
 infer = GenericModule('infer', 'pyro.infer')
 optim = GenericModule('optim', 'pyro.optim')
 ops = GenericModule('ops', 'torch')
+
+
+# These are standard backends.
+register_backend('pyro', {
+    'distributions': 'pyro.distributions',
+    'handlers': 'pyro.poutine',
+    'infer': 'pyro.infer',
+    'ops': 'torch',
+    'optim': 'pyro.optim',
+    'pyro': 'pyro',
+})
+register_backend('minipyro', {
+    'distributions': 'pyro.distributions',
+    'handlers': 'pyro.poutine',
+    'infer': 'pyro.contrib.minipyro',
+    'ops': 'torch',
+    'optim': 'pyro.contrib.minipyro',
+    'pyro': 'pyro.contrib.minipyro',
+})
+register_backend('funsor', {
+    'distributions': 'funsor.distributions',
+    'handlers': 'funsor.minipyro',
+    'infer': 'funsor.minipyro',
+    'ops': 'funsor.compat.ops',
+    'optim': 'funsor.minipyro',
+    'pyro': 'funsor.minipyro',
+})
+register_backend('numpy', {
+    'distributions': 'numpyro.compat.distributions',
+    'handlers': 'numpyro.compat.handlers',
+    'infer': 'numpyro.compat.infer',
+    'ops': 'numpyro.compat.ops',
+    'optim': 'numpyro.compat.optim',
+    'pyro': 'numpyro.compat.pyro',
+})


### PR DESCRIPTION
This makes it a little easier for users to define new backends.

I've also moved some docs into a code file because I found it easier to add links in docstrings.

## Tested
- added a unit test