### PR TITLE
Clarify pyro_backend docstring

### DIFF
--- a/pyroapi/dispatch.py
+++ b/pyroapi/dispatch.py
@@ -74,7 +74,7 @@ def pyro_backend(*aliases, **new_backends):
     Context manager to set a custom backend for Pyro models.
 
     Backends can be specified either by name (for standard backends or backends
-    registered through :func:`register_backend` ) or by providing a dict
+    registered through :func:`register_backend` ) or by providing kwargs
     mapping module name to backend module name.  Standard backends include:
     pyro, minipyro, funsor, and numpy.
     """


### PR DESCRIPTION
Providing a `dict` (as previously specified)
```
    with pyro_backend({
        'distributions': 'pyro.distributions',
        'handlers': 'pyro.poutine',
        'infer': 'pyro.infer',
        'ops': 'torch',
        'optim': 'pyro.optim',
        'pyro': 'pyro',
    }):
```
results in the error
```
TypeError: unhashable type: 'dict'
```

I think this method was designed to operate on `kwargs`, which are specified as trailing `(..., key=value, ...)` parameters to the function call. e.g. this works fine
```
    with pyro_backend(
        distributions='pyro.distributions',
        handlers='pyro.poutine',
        infer='pyro.infer',
        ops='torch',
        optim='pyro.optim',
        pyro='pyro',
    ):
```
and this does too
```
    with pyro_backend(**{
        'distributions': 'pyro.distributions',
        'handlers': 'pyro.poutine',
        'infer': 'pyro.infer',
        'ops': 'torch',
        'optim': 'pyro.optim',
        'pyro': 'pyro',
    }):
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyro-ppl/pyro-api/15)
<!-- Reviewable:end -->
