### PR TITLE
Remove default funsor.minipyro backend

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,12 +6,11 @@
 Pyro API
 ========
 
-The ``pyroapi`` package dynamically dispatches among multiple Pyro backends, including standard Pyro_, NumPyro_, Funsor_, and custom user-defined backends.
+The ``pyroapi`` package dynamically dispatches among multiple Pyro backends, including standard Pyro_, NumPyro_, and custom user-defined backends.
 This package includes both **dispatch** mechanisms for use in model and inference code, and **testing** utilities to help develop and test new Pyro backends.
 
 .. _Pyro: https://pyro.ai
 .. _NumPyro: https://num.pyro.ai
-.. _Funsor: https://funsor.pyro.ai
 
 .. toctree::
    :maxdepth: 2

--- a/pyroapi/dispatch.py
+++ b/pyroapi/dispatch.py
@@ -79,7 +79,7 @@ def pyro_backend(*aliases, **new_backends):
     Backends can be specified either by name (for standard backends or backends
     registered through :func:`register_backend` ) or by providing kwargs
     mapping module name to backend module name.  Standard backends include:
-    pyro, minipyro, funsor, and numpy.
+    pyro, minipyro, and numpy.
     """
     if aliases:
         assert len(aliases) == 1
@@ -144,14 +144,6 @@ register_backend('minipyro', {
     'ops': 'torch',
     'optim': 'pyro.contrib.minipyro',
     'pyro': 'pyro.contrib.minipyro',
-})
-register_backend('funsor', {
-    'distributions': 'funsor.distributions',
-    'handlers': 'funsor.minipyro',
-    'infer': 'funsor.minipyro',
-    'ops': 'funsor.compat.ops',
-    'optim': 'funsor.minipyro',
-    'pyro': 'funsor.minipyro',
 })
 register_backend('numpy', {
     'distributions': 'numpyro.compat.distributions',

--- a/pyroapi/tests/test_svi.py
+++ b/pyroapi/tests/test_svi.py
@@ -48,8 +48,6 @@ def test_generate_data_plate(backend):
         return x
 
     data = model()
-    if type(data).__module__.startswith('funsor'):
-        pytest.xfail(reason='plate is an input, and does not appear in .shape')
     assert data.shape == (num_points,)
     mean = data.sum().item() / num_points
     assert 1.9 <= mean <= 2.1

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -10,7 +10,6 @@ PACKAGE_NAME = {
     "pyro": "pyro",
     "minipyro": "pyro",
     "numpy": "numpyro",
-    "funsor": "funsor",
 }
 
 
@@ -28,7 +27,7 @@ def test_mcmc_interface(model, backend):
         mcmc.summary()
 
 
-@pytest.mark.parametrize('backend', ['funsor', 'minipyro', 'numpy', 'pyro'])
+@pytest.mark.parametrize('backend', ['minipyro', 'numpy', 'pyro'])
 def test_not_implemented(backend):
     pytest.importorskip(PACKAGE_NAME[backend])
     with pyro_backend(backend):
@@ -39,7 +38,7 @@ def test_not_implemented(backend):
 
 
 @pytest.mark.parametrize('model', MODELS)
-@pytest.mark.parametrize('backend', ['funsor', 'minipyro', 'numpy', 'pyro'])
+@pytest.mark.parametrize('backend', ['minipyro', 'numpy', 'pyro'])
 @pytest.mark.xfail(reason='Not supported by backend.')
 def test_model_sample(model, backend):
     pytest.importorskip(PACKAGE_NAME[backend])
@@ -51,7 +50,6 @@ def test_model_sample(model, backend):
 
 @pytest.mark.parametrize('model', MODELS)
 @pytest.mark.parametrize('backend', [
-    pytest.param("funsor", marks=[pytest.mark.xfail(reason="not implemented")]),
     'minipyro',
     'numpy',
     'pyro',

--- a/test/test_tests.py
+++ b/test/test_tests.py
@@ -12,11 +12,10 @@ PACKAGE_NAME = {
     "pyro": "pyro",
     "minipyro": "pyro",
     "numpy": "numpyro",
-    "funsor": "funsor",
 }
 
 
-@pytest.fixture(params=["pyro", "minipyro", "numpy", "funsor"])
+@pytest.fixture(params=["pyro", "minipyro", "numpy"])
 def backend(request):
     pytest.importorskip(PACKAGE_NAME[request.param])
     with pyro_backend(request.param):


### PR DESCRIPTION
This PR removes the default registration for the `funsor.minipyro` backend, since it depends on `funsor.distributions` which is being deprecated in favor of backend-specific distribution namespaces as part of our push to support multiple backends in Funsor.  The `"funsor"` backend will now be registered within `funsor.minipyro` instead of in the `pyroapi` package.

This should help unblock @fehiepsi's PR: https://github.com/pyro-ppl/funsor/pull/327