### PR TITLE
Rename funsor.distributions to funsor.torch.distributions

### DIFF
--- a/pyroapi/dispatch.py
+++ b/pyroapi/dispatch.py
@@ -146,7 +146,7 @@ register_backend('minipyro', {
     'pyro': 'pyro.contrib.minipyro',
 })
 register_backend('funsor', {
-    'distributions': 'funsor.distributions',
+    'distributions': 'funsor.torch.distributions',
     'handlers': 'funsor.minipyro',
     'infer': 'funsor.minipyro',
     'ops': 'funsor.compat.ops',

--- a/pyroapi/version.py
+++ b/pyroapi/version.py
@@ -1,4 +1,4 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[],
     extras_require={
         # PyPi does not like @ versions,
-        # so I comment out the 'test' section when uploading to pypi.
+        # so please comment out the 'test' section when uploading to pypi.
         'test': [
             'flake8',
             'pytest>=5.0',

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -39,7 +39,13 @@ def test_not_implemented(backend):
 
 
 @pytest.mark.parametrize('model', MODELS)
-@pytest.mark.parametrize('backend', ['funsor', 'minipyro', 'numpy', 'pyro'])
+@pytest.mark.parametrize('backend', [
+    pytest.param("funsor", marks=[pytest.mark.xfail(
+        reason="temporarily blocked by https://github.com/pyro-ppl/funsor/pull/327")]),
+    'minipyro',
+    'numpy',
+    'pyro',
+])
 @pytest.mark.xfail(reason='Not supported by backend.')
 def test_model_sample(model, backend):
     pytest.importorskip(PACKAGE_NAME[backend])

--- a/test/test_tests.py
+++ b/test/test_tests.py
@@ -16,7 +16,13 @@ PACKAGE_NAME = {
 }
 
 
-@pytest.fixture(params=["pyro", "minipyro", "numpy", "funsor"])
+@pytest.fixture(params=[
+    "pyro",
+    "minipyro",
+    "numpy",
+    pytest.param("funsor", marks=[pytest.mark.xfail(
+        reason="temporarily blocked by https://github.com/pyro-ppl/funsor/pull/327")]),
+])
 def backend(request):
     pytest.importorskip(PACKAGE_NAME[request.param])
     with pyro_backend(request.param):


### PR DESCRIPTION
Blocking https://github.com/pyro-ppl/funsor/pull/327
Alternative to #18 

This is part of a sequence of PRs and releases to rename the funsor distributions module to `funsor.torch.distributions`. The sequence is
- [x] Pin pyro-api version in funsor tests https://github.com/pyro-ppl/funsor/pull/330
- [ ] Merge this PR
- [ ] Release pyroapi
- [ ] Bump pyro-api version in https://github.com/pyro-ppl/funsor/pull/327 and merge it
- [ ] Uncomment the xfailing test in test_dispatch.py (low priority)