### PR TITLE
Reenable funsor tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ setup(
         'test': [
             'flake8',
             'pytest>=5.0',
-            # 'pyro-ppl@https://api.github.com/repos/pyro-ppl/pyro/tarball/dev',
-            # 'numpyro@https://api.github.com/repos/pyro-ppl/numpyro/tarball/master',
-            # 'funsor@https://api.github.com/repos/pyro-ppl/funsor/tarball/master',
+            'pyro-ppl@https://api.github.com/repos/pyro-ppl/pyro/tarball/dev',
+            'numpyro@https://api.github.com/repos/pyro-ppl/numpyro/tarball/master',
+            'funsor@https://api.github.com/repos/pyro-ppl/funsor/tarball/master',
         ],
         'dev': [
             'sphinx>=2.0',

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ setup(
         'test': [
             'flake8',
             'pytest>=5.0',
-            'pyro-ppl@https://api.github.com/repos/pyro-ppl/pyro/tarball/dev',
-            'numpyro@https://api.github.com/repos/pyro-ppl/numpyro/tarball/master',
-            'funsor@https://api.github.com/repos/pyro-ppl/funsor/tarball/master',
+            # 'pyro-ppl@https://api.github.com/repos/pyro-ppl/pyro/tarball/dev',
+            # 'numpyro@https://api.github.com/repos/pyro-ppl/numpyro/tarball/master',
+            # 'funsor@https://api.github.com/repos/pyro-ppl/funsor/tarball/master',
         ],
         'dev': [
             'sphinx>=2.0',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,15 @@
 import pytest
 
 
+def pytest_configure(config):
+    try:
+        import funsor
+    except ImportError:
+        pass
+    else:
+        funsor.set_backend("torch")
+
+
 def pytest_runtest_call(item):
     try:
         item.runtest()

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -39,13 +39,7 @@ def test_not_implemented(backend):
 
 
 @pytest.mark.parametrize('model', MODELS)
-@pytest.mark.parametrize('backend', [
-    pytest.param("funsor", marks=[pytest.mark.xfail(
-        reason="temporarily blocked by https://github.com/pyro-ppl/funsor/pull/327")]),
-    'minipyro',
-    'numpy',
-    'pyro',
-])
+@pytest.mark.parametrize("backend", ["pyro", "minipyro", "numpy", "funsor"])
 @pytest.mark.xfail(reason='Not supported by backend.')
 def test_model_sample(model, backend):
     pytest.importorskip(PACKAGE_NAME[backend])

--- a/test/test_tests.py
+++ b/test/test_tests.py
@@ -16,13 +16,7 @@ PACKAGE_NAME = {
 }
 
 
-@pytest.fixture(params=[
-    "pyro",
-    "minipyro",
-    "numpy",
-    pytest.param("funsor", marks=[pytest.mark.xfail(
-        reason="temporarily blocked by https://github.com/pyro-ppl/funsor/pull/327")]),
-])
+@pytest.fixture(params=["pyro", "minipyro", "numpy", "funsor"])
 def backend(request):
     pytest.importorskip(PACKAGE_NAME[request.param])
     with pyro_backend(request.param):


### PR DESCRIPTION
This is the final step of cleanup in https://github.com/pyro-ppl/pyro-api/pull/19 following @fehiepsi 's funsor refactoring https://github.com/pyro-ppl/funsor/pull/327