### PR TITLE
Change test dependencies to .tar.gz URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.13]
+        python-version: [3.12]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.13]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'test': [
             'flake8',
             'pytest>=5.0',
-            'torch<2.5',
+            'torch<2.5',  # newer releases are blocked by https://github.com/pyro-ppl/funsor/pull/610
             'pyro-ppl @ https://github.com/pyro-ppl/pyro/archive/dev.tar.gz',
             'numpyro @ https://github.com/pyro-ppl/numpyro/archive/master.tar.gz',
             'funsor @ https://github.com/pyro-ppl/funsor/archive/master.tar.gz',

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'test': [
             'flake8',
             'pytest>=5.0',
+            'torch<2.5',
             'pyro-ppl @ https://github.com/pyro-ppl/pyro/archive/dev.tar.gz',
             'numpyro @ https://github.com/pyro-ppl/numpyro/archive/master.tar.gz',
             'funsor @ https://github.com/pyro-ppl/funsor/archive/master.tar.gz',

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ setup(
         'test': [
             'flake8',
             'pytest>=5.0',
-            'pyro-ppl@https://api.github.com/repos/pyro-ppl/pyro/tarball/dev.tar.gz',
-            'numpyro@https://api.github.com/repos/pyro-ppl/numpyro/tarball/master.tar.gz',
-            'funsor@https://api.github.com/repos/pyro-ppl/funsor/tarball/master.tar.gz',
+            'pyro-ppl @ https://github.com/pyro-ppl/pyro/archive/dev.tar.gz',
+            'numpyro @ https://github.com/pyro-ppl/numpyro/archive/master.tar.gz',
+            'funsor @ https://github.com/pyro-ppl/funsor/archive/master.tar.gz',
         ],
         'dev': [
             'sphinx>=2.0',

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ setup(
         'test': [
             'flake8',
             'pytest>=5.0',
-            'pyro-ppl@https://api.github.com/repos/pyro-ppl/pyro/tarball/dev',
-            'numpyro@https://api.github.com/repos/pyro-ppl/numpyro/tarball/master',
-            'funsor@https://api.github.com/repos/pyro-ppl/funsor/tarball/master',
+            'pyro-ppl@https://api.github.com/repos/pyro-ppl/pyro/tarball/dev.tar.gz',
+            'numpyro@https://api.github.com/repos/pyro-ppl/numpyro/tarball/master.tar.gz',
+            'funsor@https://api.github.com/repos/pyro-ppl/funsor/tarball/master.tar.gz',
         ],
         'dev': [
             'sphinx>=2.0',


### PR DESCRIPTION
Updated test dependencies to use .tar.gz URLs instead of tarball.